### PR TITLE
Always enable logging when building libusb

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -95,7 +95,13 @@ fn make_source() {
     let mut base_config = cc::Build::new();
     base_config.include(&libusb_source);
     base_config.include(libusb_source.join("libusb"));
-    base_config.define("ENABLE_LOGGING", Some("1"));
+
+    // When building libusb from source, allow use of its logging facilities to aid debugging.
+    // FIXME: This does not link correctly under MinGW due to a rustc bug, so only do it on MSVC
+    // Ref: https://github.com/rust-lang/rust/issues/47048
+    if cfg!(target_env = "msvc") {
+        base_config.define("ENABLE_LOGGING", Some("1"));
+    }
 
     if cfg!(target_os = "macos") {
         base_config.define("OS_DARWIN", Some("1"));

--- a/build.rs
+++ b/build.rs
@@ -95,6 +95,7 @@ fn make_source() {
     let mut base_config = cc::Build::new();
     base_config.include(&libusb_source);
     base_config.include(libusb_source.join("libusb"));
+    base_config.define("ENABLE_LOGGING", Some("1"));
 
     if cfg!(target_os = "macos") {
         base_config.define("OS_DARWIN", Some("1"));


### PR DESCRIPTION
This allows turning on logging by calling `libusb_set_debug` or setting the `LIBUSB_DEBUG` environment variable, which is very handy for debugging. Arch Linux packages libusb with the option enabled too.