### PR TITLE
examples: Remove unnecessary trailing semicolon

### DIFF
--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -95,7 +95,7 @@ fn display_device(dev: &*mut ffi::libusb_device) {
         print_device_descriptor(handle, descriptor);
 
         for i in 0..descriptor.bNumConfigurations {
-            let mut descriptor = mem::MaybeUninit::<*const ffi::libusb_config_descriptor>::uninit();;
+            let mut descriptor = mem::MaybeUninit::<*const ffi::libusb_config_descriptor>::uninit();
 
             match unsafe { ffi::libusb_get_config_descriptor(*dev, i, descriptor.as_mut_ptr()) } {
                 0 => {

--- a/examples/read_device.rs
+++ b/examples/read_device.rs
@@ -284,7 +284,7 @@ fn read_endpoint(
                             let mut vec = Vec::<u8>::with_capacity(256);
                             let timeout: c_uint = 1000;
 
-                            let mut transferred = mem::MaybeUninit::<c_int>::uninit();;
+                            let mut transferred = mem::MaybeUninit::<c_int>::uninit();
 
                             match transfer_type {
                                 ffi::constants::LIBUSB_TRANSFER_TYPE_INTERRUPT => {


### PR DESCRIPTION
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>