### PR TITLE
travis: Add a job without libusb-1.0 binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,18 @@ matrix:
         - pkg-config --modversion libusb-1.0
       script:
         - cargo test --verbose --all
+    - name: linux-no-pkgconfig
+      os: linux
+      rust: stable
+      addons:
+        apt:
+          packages:
+            - libudev-dev
+      before_script:
+        - pkg-config --libs libudev
+        - pkg-config --modversion libudev
+      script:
+        - cargo test --verbose --all
     - name: osx
       os: osx
       rust: stable


### PR DESCRIPTION
The job ensures we can build libusb-1.0 from source, when it is not
available on the build host.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>