### PR TITLE
Fix win32 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,6 +20,14 @@ environment:
       VCPKGRS_DYNAMIC: 1
       RUST_BACKTRACE: 1
 
+      # stable i686 with dynamic libusb from vcpkg
+    - TARGET: i686-pc-windows-msvc
+      RUST_CHANNEL: stable
+      VCPKG_TARGET: x86-windows
+      LIBUSB_USE_PKG_CONFIG: 1
+      VCPKGRS_DYNAMIC: 1
+      RUST_BACKTRACE: 1
+
 install:
   - ps: |
       # Install Rust

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,15 @@ matrix:
       rust: stable
       script:
         - cargo test --verbose --all
+    - name: windows
+      os: windows
+      rust: stable
+      env:
+        - VCPKG_ROOT: $TRAVIS_BUILD_DIR/vcp
+        - VCPKG_PLATFORM: x64-windows-static
+      before_script:
+        - git clone https://github.com/Microsoft/vcpkg.git vcp
+        - if [ $TRAVIS_OS_NAME == "windows" ] ; then  vcp/bootstrap-vcpkg.bat; else vcp/bootstrap-vcpkg.sh; fi
+        - vcp/vcpkg.exe install libusb:$VCPKG_PLATFORM
+      script:
+        - cargo test --verbose --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,7 @@ before_script:
         [ $TRAVIS_OS_NAME == "windows" ] && vcp/bootstrap-vcpkg.bat || vcp/bootstrap-vcpkg.sh
         ./vcp/vcpkg install libusb:$VCPKG_PLATFORM
     fi
-script: cargo test --verbose --all
+script:
+  - cargo test --verbose --all
+  - cargo build --examples
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,48 @@
 language: rust
+rust: stable
 
 matrix:
   include:
-    - name: linux-pkgconfig
+    - name: Linux with packaged libusb-1.0 library
       os: linux
-      rust: stable
       addons:
         apt:
           packages:
             - libusb-1.0-0-dev
-      before_script:
-        - pkg-config --libs libusb-1.0
-        - pkg-config --modversion libusb-1.0
-      script:
-        - cargo test --verbose --all
-    - name: linux-no-pkgconfig
+      env:
+        - PKGCONFIG: libusb-1.0 libudev
+    - name: Linux building libusb-1.0 from source
       os: linux
-      rust: stable
       addons:
         apt:
           packages:
             - libudev-dev
-      before_script:
-        - pkg-config --libs libudev
-        - pkg-config --modversion libudev
-      script:
-        - cargo test --verbose --all
-    - name: osx
+      env:
+        - PKGCONFIG: libudev
+    - name: OS X building libusb-1.0 from source
       os: osx
-      rust: stable
-      script:
-        - cargo test --verbose --all
-    - name: windows
+    - name: Windows 64-bit using vcpkg
       os: windows
-      rust: stable
       env:
         - VCPKG_ROOT: $TRAVIS_BUILD_DIR/vcp
         - VCPKG_PLATFORM: x64-windows-static
-      before_script:
-        - git clone https://github.com/Microsoft/vcpkg.git vcp
-        - if [ $TRAVIS_OS_NAME == "windows" ] ; then  vcp/bootstrap-vcpkg.bat; else vcp/bootstrap-vcpkg.sh; fi
-        - vcp/vcpkg.exe install libusb:$VCPKG_PLATFORM
-      script:
-        - cargo test --verbose --all
+before_script:
+  - |
+    if [ "$TARGET" != "" ]; then
+        echo "Rust extra toolchain"
+        rustup toolchain install ${TARGET}
+        rustup default ${TARGET}
+    fi
+
+    for pkg in $PKGCONFIG; do
+        echo "pkgconfig information:"
+        echo " $pkg version: $(pkg-config --modversion $pkg) libs: $(pkg-config --libs $pkg)"
+    done
+
+    if [ "$VCPKG_PLATFORM" != "" ]; then
+        echo "Handle vcpkg support"
+        git clone https://github.com/Microsoft/vcpkg.git vcp
+        [ $TRAVIS_OS_NAME == "windows" ] && vcp/bootstrap-vcpkg.bat || vcp/bootstrap-vcpkg.sh
+        ./vcp/vcpkg install libusb:$VCPKG_PLATFORM
+    fi
+script: cargo test --verbose --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,14 @@ matrix:
       env:
         - VCPKG_ROOT: $TRAVIS_BUILD_DIR/vcp
         - VCPKG_PLATFORM: x64-windows-static
+        - TARGET: stable-x86_64-pc-windows-msvc
+    - name: Windows 32-bit using vcpkg
+      os: windows
+      env:
+        - VCPKG_ROOT: $TRAVIS_BUILD_DIR/vcp
+        - VCPKG_PLATFORM: x86-windows-static
+        - TARGET: stable-i686-pc-windows-msvc
+      os: windows
 before_script:
   - |
     if [ "$TARGET" != "" ]; then

--- a/build.rs
+++ b/build.rs
@@ -24,16 +24,8 @@ pub fn link_framework(name: &str) {
 
 #[cfg(target_env = "msvc")]
 fn find_libusb_pkg(_statik: bool) -> bool {
-    match vcpkg::probe_package("libusb-1.0") {
-        Ok(lib) => {
-            for lib_dir in &lib.link_paths {
-                println!("cargo:lib={}", lib_dir.to_str().unwrap());
-            }
-            for include_dir in &lib.include_paths {
-                println!("cargo:include={}", include_dir.to_str().unwrap());
-            }
-            true
-        }
+    match vcpkg::Config::new().find_package("libusb") {
+        Ok(_) => true,
         Err(e) => {
             println!("Can't find libusb pkg: {:?}", e);
             false

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ pub fn link_framework(name: &str) {
 }
 
 #[cfg(target_env = "msvc")]
-fn find_libusb_pkg() -> bool {
+fn find_libusb_pkg(_statik: bool) -> bool {
     match vcpkg::probe_package("libusb-1.0") {
         Ok(lib) => {
             for lib_dir in &lib.link_paths {
@@ -42,14 +42,13 @@ fn find_libusb_pkg() -> bool {
 }
 
 #[cfg(not(target_env = "msvc"))]
-fn find_libusb_pkg() -> bool {
-    match pkg_config::probe_library("libusb-1.0") {
-        Ok(lib) => {
-            for lib_dir in &lib.link_paths {
-                println!("cargo:lib={}", lib_dir.to_str().unwrap());
-            }
-            for include_dir in &lib.include_paths {
-                println!("cargo:include={}", include_dir.to_str().unwrap());
+fn find_libusb_pkg(statik: bool) -> bool {
+    match pkg_config::Config::new().statik(statik).probe("libusb-1.0") {
+        Ok(l) => {
+            for lib in l.libs {
+                if statik {
+                    println!("cargo:rustc-link-lib=static={}", lib);
+                }
             }
             true
         }
@@ -193,7 +192,11 @@ fn make_source() {
 }
 
 fn main() {
-    if !find_libusb_pkg() {
+    let statik = std::env::var("CARGO_CFG_TARGET_FEATURE")
+        .map(|s| s.contains("crt-static"))
+        .unwrap_or_default();
+
+    if !find_libusb_pkg(statik) {
         extract_source();
         make_source();
     }


### PR DESCRIPTION
This is a little bit involving PR as it ends fixing multiple issues found while we were debugging this.

The culprit was the calling convention for Win32. It must be "stdcall" on Win32 and "C" on the other use cases. We ended using the "system" calling convention.

The "system" calling convention is, usually the same as extern "C". The exception is on Win32, in which case it's "stdcall", or what you should use to link to the Windows API itself.

One exception to this rule was "libusb_set_option" as it is a variadic function and this must use "C" or "cdecl" calling conventions as it is almost impossible to get it right with "stdcall" because of only the caller really knows how many arguments were passed in order to clean them up.

This fixes linking on Win32 platforms.

Fixes: #5 