### PR TITLE
travis: Ensure libusb-1.0 is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
           packages:
             - libusb-1.0-0-dev
       env:
-        - PKGCONFIG: libusb-1.0 libudev
+        - PKGCONFIG: libusb-1.0
     - name: Linux building libusb-1.0 from source
       os: linux
       addons:


### PR DESCRIPTION
When using the binary package, we only need libusb-1.0 as it is
already built.

This commit drops the check for libudev when it is not needed.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>