### PR TITLE
Add vendored feature to force library build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,14 @@ build = "build.rs"
 [badges]
 travis-ci = { repository = "a1ien/libusb1-sys" }
 
+[features]
+vendored = []
+
 [dependencies]
 libc = "0.2"
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"
-
 
 [build-dependencies]
 cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -188,7 +188,7 @@ fn main() {
         .map(|s| s.contains("crt-static"))
         .unwrap_or_default();
 
-    if !find_libusb_pkg(statik) {
+    if cfg!(feature = "vendored") || !find_libusb_pkg(statik) {
         extract_source();
         make_source();
     }


### PR DESCRIPTION
With the vendored flag we can force the library build regardes of it being found on the system. I'm also sending a PR to rusb to have the same feature that gets passed down to this crate.