### PR TITLE
MSVC requires an option to specify source charset.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -157,6 +157,8 @@ fn make_source() {
     if cfg!(windows) {
         #[cfg(target_env = "msvc")]
         base_config.define("_TIMESPEC_DEFINED", Some("1"));
+        #[cfg(target_env = "msvc")]
+        base_config.flag("/source-charset:utf-8");
 
         base_config.warnings(false);
         base_config.define("OS_WINDOWS", Some("1"));


### PR DESCRIPTION
This will fix https://github.com/a1ien/libusb1-sys/issues/15