### PR TITLE
Export metadata for dependent crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/a1ien/libusb1-sys.git"
 readme = "README.md"
 keywords = ["usb", "libusb", "hardware", "bindings"]
 edition = "2018"
+links = "usb-1.0" # Required for metadata passing to work
 exclude = [
     ".travis.yml",
     ".appveyor.yml"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ fn main() {
 }
 ```
 
+### Native dependencies
+
+`libusb1-sys` exports [metadata] so that dependent crates can find the correct `libusb.h` header
+and compile native code that depends on `libusb`. If a crate has a direct dependency on `libusb1-sys`,
+its build script has access to the following environment variables:
+
+* `DEP_USB_1.0_INCLUDE` contains the include path with the correct `libusb.h`
+* `DEP_USB_1.0_VENDORED` is set with a value of `1` if `libusb1-sys` compiled and linked to
+its vendored copy of `libusb`
+* `DEP_USB_1.0_STATIC`  is set with a value of `1` if static linkage has been used instead of
+dynamic.
+
+[metadata]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key
+
 ### Finding Help
 Since `libusb1-sys` is no more than a wrapper around the native `libusb` library, the best source for
 help is the information already available for `libusb`:


### PR DESCRIPTION
Export enough metadata to allow the dependencies to compile their native
code against the exact `libusb` used.

One can see an example of using this information [here](https://github.com/tanriol/libftdi1-sys/pull/13/commits/e4c71b52fbf1e93f2ae8bfdfe0fb7949d2da11e8#diff-a7b0a2dee0126cddf994326e705a91ea) in a `libftdi1-sys` PR. The PR turned out to need `include` (to compile against it) and `static` (to forbid linking to `libftdi` dynamically if `libusb` is linked statically). `vendored` turned out to be unused for now, but may be needed later if `libftdi1-sys` adds linking statically to the system version.