### PR TITLE
Add line numbers to debug symbols

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -107,11 +107,6 @@ fn make_source() {
     base_config.include(&libusb_source);
     base_config.include(libusb_source.join("libusb"));
 
-    // Include line numbers for debugging libusb C code when performing debug builds
-    if env::var("PROFILE").unwrap_or(String::new()) == "debug" {
-        base_config.flag("-g");
-    }
-
     // When building libusb from source, allow use of its logging facilities to aid debugging.
     // FIXME: This does not link correctly under MinGW due to a rustc bug, so only do it on MSVC
     // Ref: https://github.com/rust-lang/rust/issues/47048
@@ -126,6 +121,7 @@ fn make_source() {
         link_framework("IOKit");
         link("objc", false);
     }
+
     if cfg!(target_os = "linux") {
         base_config.define("OS_LINUX", Some("1"));
         base_config.define("HAVE_ASM_TYPES_H", Some("1"));
@@ -173,6 +169,11 @@ fn make_source() {
 
         base_config.file(libusb_source.join("libusb/os/poll_posix.c"));
         base_config.file(libusb_source.join("libusb/os/threads_posix.c"));
+
+        // Include line numbers for debugging libusb C code when performing debug builds
+        if env::var("PROFILE").unwrap_or(String::new()) == "debug" {
+            base_config.flag("-g");
+        }
     }
 
     if cfg!(windows) {

--- a/build.rs
+++ b/build.rs
@@ -107,6 +107,11 @@ fn make_source() {
     base_config.include(&libusb_source);
     base_config.include(libusb_source.join("libusb"));
 
+    // Include line numbers for debugging libusb C code when performing debug builds
+    if env::var("PROFILE").unwrap_or(String::new()) == "debug" {
+        base_config.flag("-g");
+    }
+
     // When building libusb from source, allow use of its logging facilities to aid debugging.
     // FIXME: This does not link correctly under MinGW due to a rustc bug, so only do it on MSVC
     // Ref: https://github.com/rust-lang/rust/issues/47048

--- a/build.rs
+++ b/build.rs
@@ -171,6 +171,7 @@ fn make_source() {
         base_config.file(libusb_source.join("libusb/os/threads_posix.c"));
 
         // Include line numbers for debugging libusb C code when performing debug builds
+        base_config.define("ENABLE_LOGGING", Some("1"));
         if env::var("PROFILE").unwrap_or(String::new()) == "debug" {
             base_config.flag("-g");
         }

--- a/build.rs
+++ b/build.rs
@@ -73,17 +73,17 @@ fn unpack<R: Read>(data: R, dst: &Path) -> std::io::Result<()> {
 }
 
 fn extract_source() -> PathBuf {
-    use libflate::gzip::Decoder;
-    use std::{fs, io::Cursor};
+    // use libflate::gzip::Decoder;
+    // use std::{fs, io::Cursor};
+    //
+    // let basename = format!("libusb-{}", VERSION);
+    // let filename = format!("libusb/{}.tar.gz", basename);
 
-    let basename = format!("libusb-{}", VERSION);
-    let filename = format!("libusb/{}.tar.gz", basename);
-
-    let mut source_dir = PathBuf::from(env::var("OUT_DIR").unwrap()).join("source");
-    let data = Cursor::new(fs::read(&filename).unwrap());
-    let gz_decoder = Decoder::new(data).unwrap();
-    unpack(gz_decoder, &source_dir).unwrap();
-    source_dir.push(basename);
+    let mut source_dir = PathBuf::from("../libusb");
+    // let data = Cursor::new(fs::read(&filename).unwrap());
+    // let gz_decoder = Decoder::new(data).unwrap();
+    // unpack(gz_decoder, &source_dir).unwrap();
+    // source_dir.push(basename);
     source_dir
 }
 
@@ -130,8 +130,13 @@ fn make_source() {
         base_config.define("USBI_TIMERFD_AVAILABLE", Some("1"));
         base_config.file(libusb_source.join("libusb/os/linux_netlink.c"));
         base_config.file(libusb_source.join("libusb/os/linux_usbfs.c"));
+        base_config.file(libusb_source.join("libusb/os/events_posix.c"));
         base_config.define("POLL_NFDS_TYPE", Some("nfds_t"));
         base_config.define("_GNU_SOURCE", Some("1"));
+        base_config.define("EVENTS_POSIX", Some("1"));
+        base_config.define("HAVE_CLOCK_GETTIME", Some("1"));
+        base_config.define("HAVE_NFDS_T", Some("1"));
+        base_config.define("HAVE_PIPE2", Some("1"));
     }
 
     if cfg!(unix) {
@@ -167,7 +172,6 @@ fn make_source() {
             _ => {}
         };
 
-        base_config.file(libusb_source.join("libusb/os/poll_posix.c"));
         base_config.file(libusb_source.join("libusb/os/threads_posix.c"));
 
         // Include line numbers for debugging libusb C code when performing debug builds


### PR DESCRIPTION
When I was trying to debug a file descriptor pointer deferencing problem, I eventually had to end up stepping through libusb C source with gdb. It proved to be very helpful in debugging my issue.

If it's alright with you, this PR formalizes my debugging change, but only for debug builds of course. 

Tested against debug:

```
readelf --debug-dump=decodedline ./rust/target/aarch64-linux-android/debug/build/libusb1-sys-80e4748e2bb82924/out/libusb.a | head -n 10

/home/bgardner/workspace/rust-usbip-server/rust/target/aarch64-linux-android/debug/build/libusb1-sys-80e4748e2bb82924/out/source/libusb-1.0.23/libusb/os/linux_netlink.c:
sb-1.0.23/libusb/os/linux_netlink.c          100                   0               x
sb-1.0.23/libusb/os/linux_netlink.c            0                 0xc               x
```

and release: 
```
readelf --debug-dump=decodedline ./rust/target/aarch64-linux-android/release/build/libusb1-sys-9997fb2f60af5d05/out/libusb.a | head -n 10

File: ./rust/target/aarch64-linux-android/release/build/libusb1-sys-9997fb2f60af5d05/out/libusb.a(linux_netlink.o)

File: ./rust/target/aarch64-linux-android/release/build/libusb1-sys-9997fb2f60af5d05/out/libusb.a(linux_usbfs.o)
```