### PR TITLE
Fix windows cross compile to android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "libusb1-sys"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>",
             "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "FFI bindings for libusb."


### PR DESCRIPTION
There were several places in the `build.rs` where it was checking `cfg!()` for values, which will be the ones from the host system when cross compiling. I updated these to all use cargo environment variables instead, so cross compiling should work.