### PR TITLE
Export libc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,9 @@
 pub mod constants;
 
 use self::constants::*;
-use libc::{c_char, c_int, c_short, c_uchar, c_uint, c_void, ssize_t, timeval};
+pub use libc::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_void, ssize_t, timeval, time_t};
+#[cfg(not(windows))]
+pub use libc::suseconds_t;
 
 #[repr(C)]
 pub struct libusb_context {


### PR DESCRIPTION
This PR exports libc, so that libc can be removed as a dependency for rusb. This is intended to allow for easily replacing this crate while still using rusb on a platform that doesn't have a libc—e.g. WASM. I've written a crate that is ABI- and API-compatible with this crate and libusb that uses WebUSB, but would still like to be able to use rusb and other crates that depend on it. Cargo's `patch` feature makes that easy, but then it's still necessary to define a separate libc crate to define the few types that it uses.

If this gets merged, I'll send another PR to rusb to not depend on libc any more and only use this crate.